### PR TITLE
Require email verification

### DIFF
--- a/environments/environment.prod.ts
+++ b/environments/environment.prod.ts
@@ -1,3 +1,3 @@
 export const environment = {
-  DJANGO_API_BASE_URL: "https://django.bridge.financial",
+  DJANGO_API_BASE_URL: 'https://django.bridge.financial',
 };

--- a/src/app/auth/sign-up/[[...industry]]/page.tsx
+++ b/src/app/auth/sign-up/[[...industry]]/page.tsx
@@ -1,9 +1,9 @@
-"use client";
+'use client';
 
-import { SignUpRequest, useLoginUser } from "@/services/users.service";
-import { QuestionnaireRoutes } from "@/types/routes.enum";
-import { useRouter, useSearchParams } from "next/navigation";
-import SignUpForm from "../SignUpForm";
+import { SignUpRequest, useLoginUser } from '@/services/users.service';
+import { AuthRoutes, QuestionnaireRoutes } from '@/types/routes.enum';
+import { useRouter, useSearchParams } from 'next/navigation';
+import SignUpForm from '../SignUpForm';
 
 const SignUpPage = ({ params }: { params: { industry: string[] } }) => {
   const router = useRouter();
@@ -12,16 +12,20 @@ const SignUpPage = ({ params }: { params: { industry: string[] } }) => {
   const { mutateAsync: login } = useLoginUser();
 
   const handleRedirectAfterSignUp = (formValues: SignUpRequest) => {
-    login(
-      { email: formValues.email, password: formValues.password },
-      {
-        onSuccess: () => {
-          router.push(
-            `${QuestionnaireRoutes.VALUATION}?${searchParams.toString()}`,
-          );
-        },
-      },
-    );
+    if (process.env.NEXT_PUBLIC_REQUIRE_EMAIL_VERIFICATION) {
+      router.push(AuthRoutes.VERIFY_EMAIL_SENT);
+    } else {
+      login(
+        { email: formValues.email, password: formValues.password },
+        {
+          onSuccess: () => {
+            router.push(
+              `${QuestionnaireRoutes.VALUATION}?${searchParams.toString()}`
+            );
+          },
+        }
+      );
+    }
   };
 
   return (
@@ -30,7 +34,7 @@ const SignUpPage = ({ params }: { params: { industry: string[] } }) => {
       onSignUp={handleRedirectAfterSignUp}
       cardContainerStyles={{
         boxShadow: 0,
-        backgroundColor: "transparent",
+        backgroundColor: 'transparent',
       }}
     />
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import ErrorBoundary from '@/components/templates/boundaries/ErrorBoundary';
 import MainProvider from '@/providers/Main.provider';
 import { CssBaseline, ThemeProvider } from '@mui/material';
 import { Inter } from 'next/font/google';
@@ -34,7 +35,7 @@ export default function RootLayout({
             <ThemeProvider theme={theme}>
               {/* CssBaseline ensures MUI's styles are applied */}
               <CssBaseline />
-              {children}
+              <ErrorBoundary>{children}</ErrorBoundary>
             </ThemeProvider>
           </MainProvider>
         </Providers>

--- a/src/components/templates/boundaries/ErrorBoundary.tsx
+++ b/src/components/templates/boundaries/ErrorBoundary.tsx
@@ -1,0 +1,53 @@
+import React, { ErrorInfo } from 'react';
+
+type ErrorBoundaryProps = {
+  children?: React.ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+
+    // Define a state variable to track whether is an error or not
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError(error: unknown) {
+    // Update state so the next render will show the fallback UI
+
+    return { hasError: true };
+  }
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // You can use your own error logging service here
+    console.log({ error, errorInfo });
+  }
+  render() {
+    // Check if the error is thrown
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return (
+        <div>
+          <h2>Oops, there is an error!</h2>
+          <button
+            type="button"
+            onClick={() => this.setState({ hasError: false })}
+          >
+            Try again?
+          </button>
+        </div>
+      );
+    }
+
+    // Return children components in case of no error
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/providers/Main.provider.tsx
+++ b/src/providers/Main.provider.tsx
@@ -1,22 +1,25 @@
-import { ReactNode } from "react";
-import { AuthProvider } from "./Auth.provider";
-import { ColorsProvider } from "./Color.provider";
-import { ErrorsProvider } from "./Errors.provider";
+import { ReactNode } from 'react';
+import { AuthProvider } from './Auth.provider';
+import { ColorsProvider } from './Color.provider';
+import { ErrorsProvider } from './Errors.provider';
+import { ToastNotificationProvider } from './ToastNotification.provider';
 
 interface MainProviderProps {
   children: ReactNode;
 }
 
 const MainProvider: React.FC<MainProviderProps> = (
-  props: MainProviderProps,
+  props: MainProviderProps
 ) => {
   const { children } = props;
   return (
-    <ErrorsProvider>
-      <AuthProvider>
-        <ColorsProvider>{children}</ColorsProvider>
-      </AuthProvider>
-    </ErrorsProvider>
+    <ToastNotificationProvider>
+      <ErrorsProvider>
+        <AuthProvider>
+          <ColorsProvider>{children}</ColorsProvider>
+        </AuthProvider>
+      </ErrorsProvider>
+    </ToastNotificationProvider>
   );
 };
 

--- a/src/providers/ToastNotification.provider.tsx
+++ b/src/providers/ToastNotification.provider.tsx
@@ -1,0 +1,64 @@
+import ToastNotification from '@/components/molecules/feedback/ToastNotification';
+import { createContext, ReactNode, useContext, useState } from 'react';
+
+type ToastNotificationType = {
+  open: (
+    message: string | React.ReactNode,
+    severity: 'error' | 'warning' | 'info' | 'success'
+  ) => void;
+};
+
+const ToastNotificationContext = createContext<ToastNotificationType>({
+  open: () => {
+    return;
+  },
+});
+
+export const ToastNotificationProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [message, setMessage] = useState<string | React.ReactNode>('');
+  const [severity, setSeverity] = useState<
+    'error' | 'warning' | 'info' | 'success'
+  >('info');
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = (
+    message: string | React.ReactNode,
+    severity: 'error' | 'warning' | 'info' | 'success'
+  ) => {
+    setMessage(message);
+    setSeverity(severity);
+    setOpen(true);
+  };
+
+  return (
+    <ToastNotificationContext.Provider
+      value={{
+        open: handleOpen,
+      }}
+    >
+      {children}
+      <ToastNotification
+        message={message}
+        severity={severity}
+        open={open}
+        setOpen={setOpen} // This will close the toast when the user clicks on it or after auto-hide
+        autoHideDuration={3000} // The toast will auto-hide after 3 seconds
+      />
+    </ToastNotificationContext.Provider>
+  );
+};
+
+// Custom hook to use the context
+export const useToastNotification = () => {
+  const context = useContext(ToastNotificationContext);
+  if (context === undefined) {
+    throw new Error(
+      'useToastNotification must be used within a QuestionnaireProvider'
+    );
+  }
+  return context;
+};


### PR DESCRIPTION
This does some updates to the error handling for any user endpoints to actually display the ToastNotification when an error occurs. I also created a `useToastNotification` hook that exposes an `open` function to easily display a toast.

The main point of this is to have an environment variable that allows us to turn on requiring email verification for sign up. If it is on, the user is redirected to the email verification screen on sign up. If it is off, they will be logged in after sign up.