### PR TITLE
Fixes secure text input

### DIFF
--- a/src/app/auth/login/LoginForm/LoginForm.component.tsx
+++ b/src/app/auth/login/LoginForm/LoginForm.component.tsx
@@ -1,17 +1,17 @@
-"use client";
+'use client';
 
-import React, { useState, ChangeEvent, FormEvent, MouseEvent } from "react";
-import ContainedButton from "@/components/atoms/buttons/ContainedButton";
-import TextInputGroup from "@/components/molecules/forms/TextInputGroup";
-import ParagraphText from "@/components/atoms/typography/ParagraphText";
-import CardWithTitle from "@/components/molecules/cards/CardWithTitle";
-import SecureTextInputGroup from "@/components/molecules/forms/SecureTextInputGroup";
-import { routePaths } from "@/types/routes.enum";
-import Link from "next/link";
-import { useLoginUser, useSessionUser } from "@/services/users.service";
-import { useAuth } from "@/providers/Auth.provider";
-import { User } from "@/types/users.types";
-import { useRouter } from "next/navigation";
+import ContainedButton from '@/components/atoms/buttons/ContainedButton';
+import ParagraphText from '@/components/atoms/typography/ParagraphText';
+import CardWithTitle from '@/components/molecules/cards/CardWithTitle';
+import SecureTextInputGroup from '@/components/molecules/forms/SecureTextInputGroup';
+import TextInputGroup from '@/components/molecules/forms/TextInputGroup';
+import { useAuth } from '@/providers/Auth.provider';
+import { useLoginUser, useSessionUser } from '@/services/users.service';
+import { routePaths } from '@/types/routes.enum';
+import { User } from '@/types/users.types';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import React, { ChangeEvent, FormEvent, MouseEvent, useState } from 'react';
 
 // Define types for form values and errors
 interface FormValues {
@@ -40,17 +40,14 @@ export const LoginForm: React.FC<LoginFormProps> = ({
 
   // STATE
   const [formValues, setFormValues] = useState<FormValues>({
-    email: "",
-    password: "",
+    email: '',
+    password: '',
   });
 
   const [formErrors, setFormErrors] = useState<FormErrors>({
-    email: "",
-    password: "",
+    email: '',
+    password: '',
   });
-
-  const [isPasswordTextSecure, setIsPasswordTextSecure] =
-    useState<boolean>(true); // State to manage secure text visibility
 
   const {} = useAuth();
 
@@ -68,11 +65,6 @@ export const LoginForm: React.FC<LoginFormProps> = ({
     });
   };
 
-  // Toggle password visibility
-  const handleSecurePressOnChange = () => {
-    setIsPasswordTextSecure(!isPasswordTextSecure);
-  };
-
   // Handle mouse down event
   const handleOnMouseDown = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault(); // Prevent the button from gaining focus
@@ -83,13 +75,13 @@ export const LoginForm: React.FC<LoginFormProps> = ({
     const errors: FormErrors = {};
 
     if (!formValues.email) {
-      errors.email = "Email is required";
+      errors.email = 'Email is required';
     } else if (!/\S+@\S+\.\S+/.test(formValues.email)) {
-      errors.email = "Invalid email address";
+      errors.email = 'Invalid email address';
     }
 
     if (!formValues.password) {
-      errors.password = "Password is required";
+      errors.password = 'Password is required';
     }
 
     setFormErrors(errors);
@@ -106,8 +98,8 @@ export const LoginForm: React.FC<LoginFormProps> = ({
       const formData = new FormData(formElement);
       loginUser(
         {
-          email: formData.get("email") as string,
-          password: formData.get("password") as string,
+          email: formData.get('email') as string,
+          password: formData.get('password') as string,
         },
         {
           onSuccess: (user: User) => {
@@ -117,7 +109,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
               router.push(routePaths.DASHBOARD);
             }
           },
-        },
+        }
       );
     }
   };
@@ -125,7 +117,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
   return (
     <CardWithTitle
       containerStyle={cardContainerStyles}
-      titleProps={{ text: "Login" }}
+      titleProps={{ text: 'Login' }}
     >
       <form onSubmit={handleSubmit}>
         <TextInputGroup
@@ -143,15 +135,13 @@ export const LoginForm: React.FC<LoginFormProps> = ({
         <SecureTextInputGroup
           label="Password"
           fullWidth={true}
-          margin={"normal"}
+          margin={'normal'}
           name="password"
           value={formValues.password}
           disabled={isPending}
           onChange={handleChange}
           error={Boolean(formErrors && formErrors.password)}
           helperText={formErrors?.password}
-          isSecure={isPasswordTextSecure}
-          securePressOnChange={handleSecurePressOnChange}
           handleOnMouseDown={handleOnMouseDown}
         />
 
@@ -164,13 +154,13 @@ export const LoginForm: React.FC<LoginFormProps> = ({
         <ContainedButton
           isLoading={isPending}
           fullWidth={true}
-          text={"Login"}
+          text={'Login'}
           type="submit"
         />
       </form>
 
       <ParagraphText variant="body2" align="center" sx={{ mt: 2 }}>
-        Don't have an account?{" "}
+        Don't have an account?{' '}
         <Link href={routePaths.SIGN_UP} color="primary">
           Sign Up
         </Link>

--- a/src/app/auth/password-reset/[uid]/[token]/PasswordResetConfirmForm/PasswordResetConfirmForm.component.tsx
+++ b/src/app/auth/password-reset/[uid]/[token]/PasswordResetConfirmForm/PasswordResetConfirmForm.component.tsx
@@ -1,19 +1,19 @@
-"use client";
-import React, { useState } from "react";
-import { Typography, Box } from "@mui/material";
-import Link from "next/link";
-import { routePaths } from "@/types/routes.enum";
-import ParagraphText from "@/components/atoms/typography/ParagraphText";
-import ContainedButton from "@/components/atoms/buttons/ContainedButton";
-import CardWithTitle from "@/components/molecules/cards/CardWithTitle";
-import SecureTextInputGroup from "@/components/molecules/forms/SecureTextInputGroup";
-import { usePasswordResetConfirm } from "@/services/users.service";
-import { useParams } from "next/navigation";
+'use client';
+import ContainedButton from '@/components/atoms/buttons/ContainedButton';
+import ParagraphText from '@/components/atoms/typography/ParagraphText';
+import CardWithTitle from '@/components/molecules/cards/CardWithTitle';
+import SecureTextInputGroup from '@/components/molecules/forms/SecureTextInputGroup';
+import { usePasswordResetConfirm } from '@/services/users.service';
+import { routePaths } from '@/types/routes.enum';
+import { Box, Typography } from '@mui/material';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import React, { useState } from 'react';
 
 const PasswordResetConfirmForm: React.FC = () => {
   // STATE
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
 
@@ -28,13 +28,13 @@ const PasswordResetConfirmForm: React.FC = () => {
   // HANDLERS
 
   const handleNewPasswordChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: React.ChangeEvent<HTMLInputElement>
   ) => {
     setNewPassword(event.target.value);
   };
 
   const handleConfirmPasswordChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: React.ChangeEvent<HTMLInputElement>
   ) => {
     setConfirmPassword(event.target.value);
   };
@@ -43,7 +43,7 @@ const PasswordResetConfirmForm: React.FC = () => {
     event.preventDefault();
 
     if (newPassword !== confirmPassword) {
-      setError("Passwords do not match");
+      setError('Passwords do not match');
       return;
     }
 
@@ -63,12 +63,12 @@ const PasswordResetConfirmForm: React.FC = () => {
         onError: (error) => {
           setError(error.message);
         },
-      },
+      }
     );
   };
 
   return (
-    <CardWithTitle titleProps={{ text: "Password Reset" }}>
+    <CardWithTitle titleProps={{ text: 'Password Reset' }}>
       {submitted ? (
         <Typography variant="body1" align="center">
           Your password has been successfully reset. You can now log in with
@@ -81,10 +81,9 @@ const PasswordResetConfirmForm: React.FC = () => {
             name="newPassword"
             value={newPassword}
             onChange={handleNewPasswordChange}
-            error={Boolean(error && newPassword === "")}
-            helperText={error && newPassword === "" ? error : ""}
+            error={Boolean(error && newPassword === '')}
+            helperText={error && newPassword === '' ? error : ''}
             fullWidth={true}
-            securePressOnChange={() => setNewPassword("")}
             handleOnMouseDown={(event) => event.preventDefault()}
           />
           <SecureTextInputGroup
@@ -92,10 +91,9 @@ const PasswordResetConfirmForm: React.FC = () => {
             name="confirmPassword"
             value={confirmPassword}
             onChange={handleConfirmPasswordChange}
-            error={Boolean(error && confirmPassword === "")}
-            helperText={error && confirmPassword === "" ? error : ""}
+            error={Boolean(error && confirmPassword === '')}
+            helperText={error && confirmPassword === '' ? error : ''}
             fullWidth={true}
-            securePressOnChange={() => setConfirmPassword("")}
             handleOnMouseDown={(event) => event.preventDefault()}
           />
           {error && (
@@ -106,7 +104,7 @@ const PasswordResetConfirmForm: React.FC = () => {
           <Box sx={{ marginTop: 2 }}>
             <ContainedButton
               type="submit"
-              text={"Reset Password"}
+              text={'Reset Password'}
               fullWidth={true}
               isLoading={isPending}
             />

--- a/src/app/auth/sign-up/SignUpForm/SignUpForm.component.tsx
+++ b/src/app/auth/sign-up/SignUpForm/SignUpForm.component.tsx
@@ -1,14 +1,14 @@
-"use client";
-import ContainedButton from "@/components/atoms/buttons/ContainedButton";
-import ParagraphText from "@/components/atoms/typography/ParagraphText";
-import CardWithTitle from "@/components/molecules/cards/CardWithTitle";
-import SecureTextInputGroup from "@/components/molecules/forms/SecureTextInputGroup";
-import TextInputGroup from "@/components/molecules/forms/TextInputGroup";
-import { useIndustries } from "@/services/industries.service";
-import { SignUpRequest, useSignUp } from "@/services/users.service";
-import { colors } from "@/theme/theme";
-import { Industry } from "@/types/industries.types";
-import { externalUrls, routePaths } from "@/types/routes.enum";
+'use client';
+import ContainedButton from '@/components/atoms/buttons/ContainedButton';
+import ParagraphText from '@/components/atoms/typography/ParagraphText';
+import CardWithTitle from '@/components/molecules/cards/CardWithTitle';
+import SecureTextInputGroup from '@/components/molecules/forms/SecureTextInputGroup';
+import TextInputGroup from '@/components/molecules/forms/TextInputGroup';
+import { useIndustries } from '@/services/industries.service';
+import { SignUpRequest, useSignUp } from '@/services/users.service';
+import { colors } from '@/theme/theme';
+import { Industry } from '@/types/industries.types';
+import { externalUrls, routePaths } from '@/types/routes.enum';
 import {
   Autocomplete,
   Box,
@@ -16,9 +16,9 @@ import {
   FormControlLabel,
   TextField,
   Typography,
-} from "@mui/material";
-import Link from "next/link";
-import React, { MouseEvent, useEffect, useState } from "react";
+} from '@mui/material';
+import Link from 'next/link';
+import React, { MouseEvent, useEffect, useState } from 'react';
 
 export interface SignUpFormProps {
   title?: string;
@@ -34,20 +34,18 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
 }): React.ReactNode => {
   // STATE
   const [formValues, setFormValues] = useState<SignUpRequest>({
-    first_name: "",
-    last_name: "",
-    company_name: "",
-    industry: "",
-    email: "",
-    password: "",
+    first_name: '',
+    last_name: '',
+    company_name: '',
+    industry: '',
+    email: '',
+    password: '',
     terms: false,
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [selectedIndustry, setSelectedIndustry] = useState<
     Industry | undefined
   >();
-  const [isPasswordTextSecure, setIsPasswordTextSecure] =
-    useState<boolean>(true); // State to manage secure text visibility
 
   // QUERIES
   const { data: industries } = useIndustries();
@@ -59,14 +57,14 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
     const { name, value, type, checked } = e.target;
     setFormValues({
       ...formValues,
-      [name]: type === "checkbox" ? checked : value,
+      [name]: type === 'checkbox' ? checked : value,
     });
   };
 
   const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
     const { name } = e.target;
     setErrors((prev) => {
-      return { ...prev, [name]: "" };
+      return { ...prev, [name]: '' };
     });
   };
 
@@ -74,8 +72,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
     if (industryName && industries?.results?.length) {
       // Find the industry that matches the industryName (case insensitive)
       const existingIndustry = industries.results.find(
-        (industry) =>
-          industry.name.toLowerCase() === industryName.toLowerCase(),
+        (industry) => industry.name.toLowerCase() === industryName.toLowerCase()
       );
 
       // If the industry is found and it's different from the selected one, update the selectedIndustry
@@ -94,30 +91,30 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
   const checkFormValidity = () => {
     const newErrors: Record<string, string> = {};
     if (!formValues.first_name) {
-      newErrors["first_name"] = "First name is required";
+      newErrors['first_name'] = 'First name is required';
     }
     if (!formValues.last_name) {
-      newErrors["last_name"] = "Last name is required";
+      newErrors['last_name'] = 'Last name is required';
     }
     if (!formValues.company_name) {
-      newErrors["company_name"] = "Company name is required";
+      newErrors['company_name'] = 'Company name is required';
     }
     if (!formValues.industry) {
-      newErrors["industry"] = "Industry is required";
+      newErrors['industry'] = 'Industry is required';
     }
     if (!formValues.email) {
-      newErrors["email"] = "Email is required";
+      newErrors['email'] = 'Email is required';
     }
     if (!formValues.password) {
-      newErrors["password"] = "Password is required";
+      newErrors['password'] = 'Password is required';
     } else if (formValues.password.length < 8) {
-      newErrors["password"] = "Password must be at least 8 characters";
+      newErrors['password'] = 'Password must be at least 8 characters';
     } else if (!/\d/.test(formValues.password)) {
-      newErrors["password"] =
-        "Password must have at least 1 number and 1 special character";
+      newErrors['password'] =
+        'Password must have at least 1 number and 1 special character';
     }
     if (!formValues.terms) {
-      newErrors["terms"] = "Must accept terms";
+      newErrors['terms'] = 'Must accept terms';
     }
 
     setErrors(newErrors);
@@ -144,11 +141,6 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
     }
   };
 
-  // Toggle password visibility
-  const handleSecurePressOnChange = () => {
-    setIsPasswordTextSecure(!isPasswordTextSecure);
-  };
-
   // Handle mouse down event
   const handleOnMouseDownForSecure = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault(); // Prevent the button from gaining focus
@@ -158,9 +150,9 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
     <CardWithTitle
       containerStyle={cardContainerStyles}
       titleProps={{
-        text: "Create an Account",
+        text: 'Create an Account',
         sx: {
-          textAlign: "left",
+          textAlign: 'left',
         },
       }}
     >
@@ -168,12 +160,12 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
         align="left"
         sx={{
           marginTop: 0,
-          "& a": {
+          '& a': {
             color: colors.bridgeDarkPurple,
           },
         }}
       >
-        Already have an account?{" "}
+        Already have an account?{' '}
         <span
           style={{
             color: colors.bridgeDarkPurple,
@@ -181,7 +173,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
         >
           <Link href={routePaths.LOGIN} color="primary">
             Sign In
-          </Link>{" "}
+          </Link>{' '}
         </span>
         here
       </ParagraphText>
@@ -231,7 +223,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
             // Update selectedIndustry and form values when a new industry is selected
             setSelectedIndustry(value || undefined);
             setFormValues((prev: any) => {
-              return { ...prev, industry: value ? value.id.toString() : "" };
+              return { ...prev, industry: value ? value.id.toString() : '' };
             });
           }}
           renderInput={(params) => (
@@ -274,8 +266,6 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
           onChange={handleChange}
           error={Boolean(errors && errors.password)}
           helperText={errors?.password}
-          isSecure={isPasswordTextSecure}
-          securePressOnChange={handleSecurePressOnChange}
           handleOnMouseDown={handleOnMouseDownForSecure}
           onBlur={handleBlur}
         />
@@ -286,8 +276,8 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
               checked={formValues.terms}
               onChange={handleChange}
               sx={{
-                "&.Mui-checked": {
-                  color: "#77CE80", // green when checked
+                '&.Mui-checked': {
+                  color: '#77CE80', // green when checked
                 },
               }}
             />
@@ -297,12 +287,12 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
               component="p"
               sx={{
                 fontSize: { xs: 14, md: 14, lg: 14 },
-                "& a": {
+                '& a': {
                   color: colors.bridgeDarkPurple,
                 },
               }}
             >
-              I accept the Bridge{" "}
+              I accept the Bridge{' '}
               <Link
                 legacyBehavior={true}
                 target="_blank"
@@ -325,7 +315,7 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
         )}
         <Box sx={{ marginTop: 3 }}>
           <ContainedButton
-            type={"submit"}
+            type={'submit'}
             text="Sign Up"
             fullWidth={true}
             sx={{ padding: 1.5 }}

--- a/src/components/molecules/forms/SecureTextInputGroup/SecureTextInputGroup.component.tsx
+++ b/src/components/molecules/forms/SecureTextInputGroup/SecureTextInputGroup.component.tsx
@@ -1,26 +1,24 @@
-import React from "react";
+import useMergeStyles from '@/hooks/useMergeStyles.hook';
+import { colors } from '@/theme/theme';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import {
-  TextField,
-  InputAdornment,
   IconButton,
+  InputAdornment,
+  TextField,
   TextFieldProps,
-} from "@mui/material";
-import Visibility from "@mui/icons-material/Visibility";
-import VisibilityOff from "@mui/icons-material/VisibilityOff";
-import { colors } from "@/theme/theme";
-import useMergeStyles from "@/hooks/useMergeStyles.hook";
+} from '@mui/material';
+import React, { useState } from 'react';
 
 // Define the types for icon components
 export type IconComponent = React.ComponentType<React.SVGProps<SVGSVGElement>>;
 
 export interface SecureTextInputGroupProps
-  extends Omit<TextFieldProps, "variant" | "type"> {
-  isSecure?: boolean;
-  securePressOnChange: () => void;
+  extends Omit<TextFieldProps, 'variant' | 'type'> {
   handleOnMouseDown: (event: React.MouseEvent<HTMLButtonElement>) => void;
   SecureTextOnIcon?: IconComponent;
   SecureTextOffIcon?: IconComponent;
-  sx?: TextFieldProps["sx"];
+  sx?: TextFieldProps['sx'];
 }
 
 /**
@@ -63,39 +61,38 @@ const SecureTextInputGroup: React.FC<SecureTextInputGroupProps> = ({
   label,
   name,
   value,
-  margin = "normal",
+  margin = 'normal',
   onChange,
   error,
-  securePressOnChange,
   handleOnMouseDown,
   fullWidth,
-  isSecure = true,
   helperText,
   SecureTextOnIcon = Visibility,
   SecureTextOffIcon = VisibilityOff,
   sx = {},
   ...rest
 }) => {
+  const [isSecure, setIsSecure] = useState(true);
   const mergedStyles = useMergeStyles(
     {
-      "& .MuiFilledInput-underline:before": {
-        borderBottomColor: "rgba(0, 0, 0, .5)",
+      '& .MuiFilledInput-underline:before': {
+        borderBottomColor: 'rgba(0, 0, 0, .5)',
       },
-      "& .MuiFilledInput-underline:hover:before": {
+      '& .MuiFilledInput-underline:hover:before': {
         borderBottomColor: colors.bridgeLightPurple, // Color on hover
       },
-      "& .MuiFilledInput-underline:after": {
+      '& .MuiFilledInput-underline:after': {
         borderBottomColor: colors.bridgeDarkPurple, // Color when focused
       },
       // Styles for the label
-      "& .MuiFormLabel-root": {
-        color: "rgba(0, 0, 0, .4)",
+      '& .MuiFormLabel-root': {
+        color: 'rgba(0, 0, 0, .4)',
       },
-      "& .MuiFormLabel-root.Mui-focused": {
+      '& .MuiFormLabel-root.Mui-focused': {
         color: colors.bridgeDarkPurple, // Label color when focused
       },
     },
-    {},
+    {}
   );
 
   return (
@@ -103,7 +100,7 @@ const SecureTextInputGroup: React.FC<SecureTextInputGroupProps> = ({
       sx={mergedStyles}
       label={label}
       variant="filled"
-      type={isSecure ? "password" : "text"}
+      type={isSecure ? 'password' : 'text'}
       fullWidth={fullWidth}
       margin={margin}
       name={name}
@@ -117,14 +114,14 @@ const SecureTextInputGroup: React.FC<SecureTextInputGroupProps> = ({
           <InputAdornment position="end">
             <IconButton
               aria-label="toggle password visibility"
-              onClick={securePressOnChange}
+              onClick={() => setIsSecure((prev) => !prev)}
               onMouseDown={handleOnMouseDown}
               edge="end"
               sx={{
-                width: "36px", // Set width to create a square button
-                height: "36px", // Set height to match the width
-                borderRadius: "50%", // Ensure the button is a circle
-                padding: "6px", // Optional: Adjust padding as needed to ensure the icon fits nicely
+                width: '36px', // Set width to create a square button
+                height: '36px', // Set height to match the width
+                borderRadius: '50%', // Ensure the button is a circle
+                padding: '6px', // Optional: Adjust padding as needed to ensure the icon fits nicely
               }}
             >
               {isSecure ? <SecureTextOnIcon /> : <SecureTextOffIcon />}


### PR DESCRIPTION
I moved the state management for the secure text input group into the component, so that the default functionality of the component is to view the password when clicking the eyeball.

So, the reset password fields now work as expected with the visibility toggle