### PR TITLE
Adds stripe checkout form

### DIFF
--- a/src/components/organisms/Checkout/CheckoutForm.tsx
+++ b/src/components/organisms/Checkout/CheckoutForm.tsx
@@ -1,0 +1,38 @@
+import { BASE_URL } from '@/services/authorized-request.service';
+import { ReactNode } from 'react';
+
+export type CreateCheckoutSessionVariables = {
+  productKey: 'certified_valuation';
+  successUrl?: string;
+  cancelUrl?: string;
+};
+
+type CheckoutFormProps = {
+  children?: ReactNode;
+} & CreateCheckoutSessionVariables;
+
+/**
+ * Use this CheckoutForm, and render a button with type 'submit' in order to create a button that redirects
+ * to the hosted Checkout page.
+ */
+const CheckoutForm = ({
+  productKey,
+  successUrl,
+  cancelUrl,
+  children,
+}: CheckoutFormProps) => {
+  return (
+    <form method="post" action={`${BASE_URL}/api/create-checkout-session/`}>
+      <input type="hidden" name="product_key" value={productKey}></input>
+      {successUrl && (
+        <input type="hidden" name="success_url" value={successUrl}></input>
+      )}
+      {cancelUrl && (
+        <input type="hidden" name="cancel_url" value={cancelUrl}></input>
+      )}
+      {children}
+    </form>
+  );
+};
+
+export default CheckoutForm;

--- a/src/services/authorized-request.service.ts
+++ b/src/services/authorized-request.service.ts
@@ -1,15 +1,15 @@
-import { baseUrls } from "../utils/env-variables";
+import { baseUrls } from '../utils/env-variables';
 
-const BASE_URL =
+export const BASE_URL =
   process.env.NEXT_PUBLIC_DJANGO_API_BASE_URL ?? baseUrls.api.full;
 // Utility function to get a specific cookie by name
 export const getCookie = (
   cookieString: string,
-  name: string,
+  name: string
 ): string | null => {
   let cookieValue: string | null = null;
-  if (cookieString && cookieString !== "") {
-    const cookies = cookieString.split(";");
+  if (cookieString && cookieString !== '') {
+    const cookies = cookieString.split(';');
     for (let i = 0; i < cookies.length; i++) {
       const cookie = cookies[i].trim();
       if (cookie.startsWith(`${name}=`)) {
@@ -28,27 +28,27 @@ export interface FetchOptions extends RequestInit {
 export const fetchWithAuth = async (
   url: string,
   options: FetchOptions = {},
-  cookieString = document.cookie,
+  cookieString = document.cookie
 ): Promise<Response> => {
   const headers = new Headers({
-    "Content-Type": "application/json",
+    'Content-Type': 'application/json',
     Cookie: cookieString,
     ...options.headers,
   });
 
   // Get the CSRF token from the cookies
-  const csrfToken = getCookie(cookieString, "csrftoken");
+  const csrfToken = getCookie(cookieString, 'csrftoken');
 
   // If the CSRF token exists, include it in the headers
   if (csrfToken) {
-    headers.set("X-CSRFToken", csrfToken);
+    headers.set('X-CSRFToken', csrfToken);
   }
 
   // Perform the fetch request
   const response = await fetch(`${BASE_URL}${url}`, {
-    method: "GET",
-    credentials: "include", // To send cookies with requests
-    cache: "no-cache",
+    method: 'GET',
+    credentials: 'include', // To send cookies with requests
+    cache: 'no-cache',
     ...options,
     headers: headers,
   });


### PR DESCRIPTION
Adds a Form component that can wrap a button that will send a post request to the backend in order to be redirected to the hosted Checkout page for a given product. Right now, backend/frontend only support the 'certified_valuation' product, but should be easy to add other products now that this component is here.