### PR TITLE
css fixes for offer layout

### DIFF
--- a/.storybook/themes.ts
+++ b/.storybook/themes.ts
@@ -22,9 +22,9 @@ export const lightTheme: ThemeVars = {
   inputBorderRadius: 8,
   colorPrimary: colors.bridgeDarkPurple, // Primary accent color
   colorSecondary: colors.bridgeDarkOrange, // Secondary accent color
-  appBg: 'transparent',
-  inputTextColor: 'white',
-  appPreviewBg: 'transparent', // Light preview background
+  appBg: '#ffffff',
+  inputTextColor: '#ffffff',
+  appPreviewBg: 'white', // Light preview background
   textInverseColor: '#ffffff', // Text color for dark elements
   buttonBg: colors.bridgeDarkPurple, // Background color for buttons
   buttonBorder: colors.bridgeDarkPurple, // Border color for buttons

--- a/src/components/atoms/typography/ParagraphText/ParagraphText.stories.tsx
+++ b/src/components/atoms/typography/ParagraphText/ParagraphText.stories.tsx
@@ -5,14 +5,21 @@ const meta: Meta<typeof ParagraphText> = {
   title: 'components/atoms/typography/ParagraphText',
   component: ParagraphText,
   argTypes: {
-    children: { control: 'text' },
-    className: { control: 'text' },
-    sx: { control: 'object' },
+    children: {
+      control: 'text',
+      description: 'Text content for the paragraph',
+    },
+    className: {
+      control: 'text',
+      description: 'Custom class for the component',
+    },
+    sx: { control: 'object', description: 'Custom styles using MUI sx prop' },
     fontWeight: {
       control: {
         type: 'select',
         options: ['200', '300', '400', '500', '600', '700', '800'],
       },
+      description: 'Font weight of the paragraph text',
     },
   },
 };
@@ -27,10 +34,51 @@ export const Default: Story = {
   },
 };
 
-export const CustomStyles: Story = {
+export const ExtraLightText: Story = {
   args: {
-    children: 'This is a paragraph with custom styles.',
-    sx: { color: 'blue', textAlign: 'center' },
+    children: 'This is extra-light text.',
+    fontWeight: '200',
+  },
+};
+
+export const LightText: Story = {
+  args: {
+    children: 'This is light-weight text.',
+    fontWeight: '300',
+  },
+};
+
+export const RegularText: Story = {
+  args: {
+    children: 'This is regular-weight text.',
+    fontWeight: '400',
+  },
+};
+
+export const MediumText: Story = {
+  args: {
+    children: 'This is medium-weight text.',
+    fontWeight: '500',
+  },
+};
+
+export const SemiBoldText: Story = {
+  args: {
+    children: 'This is semi-bold text.',
     fontWeight: '600',
+  },
+};
+
+export const BoldText: Story = {
+  args: {
+    children: 'This is bold text.',
+    fontWeight: '700',
+  },
+};
+
+export const ExtraBoldText: Story = {
+  args: {
+    children: 'This is extra-bold text.',
+    fontWeight: '800',
   },
 };

--- a/src/components/atoms/typography/SubTitleText/SubTitleText.stories.tsx
+++ b/src/components/atoms/typography/SubTitleText/SubTitleText.stories.tsx
@@ -3,17 +3,26 @@ import SubTitleText from './SubTitleText.component';
 
 const meta: Meta<typeof SubTitleText> = {
   title: 'components/atoms/typography/SubTitleText',
-
   component: SubTitleText,
   argTypes: {
-    children: { control: 'text' },
-    className: { control: 'text' },
-    sx: { control: 'object' },
+    children: {
+      control: 'text',
+      description: 'Text content for the subtitle',
+    },
+    className: {
+      control: 'text',
+      description: 'Custom class for the component',
+    },
+    sx: {
+      control: 'object',
+      description: 'Custom styles using MUI sx prop',
+    },
     fontWeight: {
       control: {
         type: 'select',
         options: ['200', '300', '400', '500', '600', '700', '800'],
       },
+      description: 'Font weight of the subtitle text',
     },
   },
 };
@@ -28,10 +37,51 @@ export const Default: Story = {
   },
 };
 
-export const CustomStyles: Story = {
+export const ExtraLightText: Story = {
   args: {
-    children: 'This is a subtitle with custom styles.',
-    sx: { color: 'green', textAlign: 'right' },
+    children: 'This is an extra-light subtitle.',
+    fontWeight: '200',
+  },
+};
+
+export const LightText: Story = {
+  args: {
+    children: 'This is a light-weight subtitle.',
+    fontWeight: '300',
+  },
+};
+
+export const RegularText: Story = {
+  args: {
+    children: 'This is a regular-weight subtitle.',
+    fontWeight: '400',
+  },
+};
+
+export const MediumText: Story = {
+  args: {
+    children: 'This is a medium-weight subtitle.',
+    fontWeight: '500',
+  },
+};
+
+export const SemiBoldText: Story = {
+  args: {
+    children: 'This is a semi-bold subtitle.',
+    fontWeight: '600',
+  },
+};
+
+export const BoldText: Story = {
+  args: {
+    children: 'This is a bold subtitle.',
     fontWeight: '700',
+  },
+};
+
+export const ExtraBoldText: Story = {
+  args: {
+    children: 'This is an extra-bold subtitle.',
+    fontWeight: '800',
   },
 };

--- a/src/components/atoms/typography/TitleText/TitleText.stories.tsx
+++ b/src/components/atoms/typography/TitleText/TitleText.stories.tsx
@@ -5,9 +5,25 @@ const meta: Meta<typeof TitleText> = {
   title: 'components/atoms/typography/TitleText',
   component: TitleText,
   argTypes: {
-    children: { control: 'text' },
-    className: { control: 'text' },
-    sx: { control: 'object' },
+    children: {
+      control: 'text',
+      description: 'Text content for the title',
+    },
+    className: {
+      control: 'text',
+      description: 'Custom class for the component',
+    },
+    sx: {
+      control: 'object',
+      description: 'Custom styles using MUI sx prop',
+    },
+    fontWeight: {
+      control: {
+        type: 'select',
+        options: ['200', '300', '400', '500', '600', '700', '800'],
+      },
+      description: 'Font weight of the title text',
+    },
   },
 };
 
@@ -21,9 +37,51 @@ export const Default: Story = {
   },
 };
 
-export const CustomStyles: Story = {
+export const ExtraLightText: Story = {
   args: {
-    children: 'This is a title with custom styles.',
-    sx: { color: 'red', textAlign: 'center' },
+    children: 'This is an extra-light title.',
+    fontWeight: '200',
+  },
+};
+
+export const LightText: Story = {
+  args: {
+    children: 'This is a light-weight title.',
+    fontWeight: '300',
+  },
+};
+
+export const RegularText: Story = {
+  args: {
+    children: 'This is a regular-weight title.',
+    fontWeight: '400',
+  },
+};
+
+export const MediumText: Story = {
+  args: {
+    children: 'This is a medium-weight title.',
+    fontWeight: '500',
+  },
+};
+
+export const SemiBoldText: Story = {
+  args: {
+    children: 'This is a semi-bold title.',
+    fontWeight: '600',
+  },
+};
+
+export const BoldText: Story = {
+  args: {
+    children: 'This is a bold title.',
+    fontWeight: '700',
+  },
+};
+
+export const ExtraBoldText: Story = {
+  args: {
+    children: 'This is an extra-bold title.',
+    fontWeight: '800',
   },
 };

--- a/src/components/molecules/display-data/FeatureListItem/FeatureListItem.component.tsx
+++ b/src/components/molecules/display-data/FeatureListItem/FeatureListItem.component.tsx
@@ -1,61 +1,3 @@
-// import ParagraphText from '@/components/atoms/typography/ParagraphText';
-// import { SxProps } from '@mui/material';
-// import React from 'react';
-// import {
-//   callToActionFeatureListStyles,
-//   normalFeatureListStyles,
-//   StyledFeatureListItem,
-// } from './FeatureListItem.styles';
-
-// // Props
-// export interface FeatureListItemProps {
-//   text: string;
-//   icon: React.ReactNode;
-//   isCallToAction?: boolean;
-//   onClick?: () => void; // Make onClick optional to avoid errors
-//   containerStyle?: SxProps; // Overrides container styles
-//   textStyle?: SxProps; // Overrides text styles
-//   textVariant?: 'body1' | 'body2' | 'subtitle1' | 'subtitle2'; // Custom typography variant
-// }
-
-// // Component
-// const FeatureListItem: React.FC<FeatureListItemProps> = ({
-//   text,
-//   icon,
-//   isCallToAction = false,
-//   onClick = () => {}, // Default to no-op function if onClick is not provided
-//   containerStyle = {}, // Default to an empty object to avoid undefined errors
-//   textStyle = {}, // Default to an empty object to avoid undefined errors
-//   textVariant = 'body1', // Default to body1
-// }) => {
-//   return (
-//     <StyledFeatureListItem
-//       sx={{
-//         ...containerStyle, // Merge custom container styles
-//       }}
-//       style={{
-//         ...(isCallToAction
-//           ? callToActionFeatureListStyles
-//           : normalFeatureListStyles),
-//       }}
-//       onClick={onClick}
-//     >
-//       <div>{icon}</div>
-
-//       <ParagraphText
-//         variant={textVariant}
-//         sx={{
-//           marginLeft: 1.5,
-//           ...textStyle, // Merge custom text styles
-//         }}
-//       >
-//         {text}
-//       </ParagraphText>
-//     </StyledFeatureListItem>
-//   );
-// };
-
-// export default FeatureListItem;
 import ParagraphText from '@/components/atoms/typography/ParagraphText';
 import { SxProps } from '@mui/material';
 import React from 'react';
@@ -93,7 +35,9 @@ const FeatureListItem: React.FC<FeatureListItemProps> = ({
       }}
       onClick={onClick}
     >
-      <FeatureIconWrapper>{icon}</FeatureIconWrapper>
+      <FeatureIconWrapper isCallToAction={isCallToAction}>
+        {icon}
+      </FeatureIconWrapper>
 
       <ParagraphText
         variant={textVariant}

--- a/src/components/molecules/display-data/FeatureListItem/FeatureListItem.styles.tsx
+++ b/src/components/molecules/display-data/FeatureListItem/FeatureListItem.styles.tsx
@@ -16,13 +16,16 @@ export const StyledFeatureListItem = styled(Box, {
     : theme.palette.text.primary,
 
   // Padding is always applied
-  padding: `${theme.spacing(2)} ${theme.spacing(3)}`, // 16px top/bottom, 24px left/right
+  padding: `${theme.spacing(2)} ${theme.spacing(0)}`, // 16px top/bottom, 24px left/right
 
   // Cursor changes to pointer for Call-to-Action
   cursor: isCallToAction ? 'pointer' : 'default',
 
   // Target text (e.g., <p>) inside the component
   '& p': {
+    paddingLeft: 0,
+    marginLeft: 0,
+
     fontWeight: isCallToAction ? '800 !important' : 'initial', // Enforce fontWeight
     whiteSpace: isCallToAction ? 'nowrap' : 'normal', // No wrapping for Call-to-Action
     overflow: isCallToAction ? 'hidden' : 'visible', // Prevent overflow
@@ -33,18 +36,20 @@ export const StyledFeatureListItem = styled(Box, {
 // Styled Component for FeatureListItem
 
 // Styled Component for Icon Wrapper
-export const FeatureIconWrapper = styled(Box)({
-  maxWidth: 18, // Updated size for Call-to-Action
-  maxHeight: 18,
+export const FeatureIconWrapper = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'isCallToAction',
+})<{ isCallToAction?: boolean }>(({ theme, isCallToAction = false }) => ({
+  maxWidth: 35,
+  maxHeight: 35,
   width: '100%',
   height: '100%',
   display: 'flex',
+  marginTop: isCallToAction ? 'initial' : 1.3,
   justifyContent: 'center',
   alignItems: 'center',
-  padding: 0, // Remove all padding
   overflow: 'hidden', // Prevent content overflow
   boxSizing: 'border-box', // Ensures consistent sizing
-
+  padding: isCallToAction ? `${theme.spacing(1)} ${theme.spacing(0)}` : 0,
   // Target images and SVGs within this Box
   '& img, & svg': {
     maxWidth: '100%',
@@ -52,4 +57,4 @@ export const FeatureIconWrapper = styled(Box)({
     width: 'auto',
     height: 'auto',
   },
-});
+}));

--- a/src/components/molecules/display-data/TestimonialItem/TestimonialItem.component.tsx
+++ b/src/components/molecules/display-data/TestimonialItem/TestimonialItem.component.tsx
@@ -1,10 +1,16 @@
 import ParagraphText from '@/components/atoms/typography/ParagraphText';
 import TitleText from '@/components/atoms/typography/TitleText';
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import Image from 'next/image';
 import React from 'react';
 import { StyledTestimonial } from './TestimonialItem.styles';
 
+// preview compiled with 1 error
+// 62% building 2/3 entries 357/367 dependencies 1413/155 modulesWARN Failed to parse /Users/landonjohnson/dev-local/workplaces/bridge-financial/bridge-nextjs/src/components/organisms/MessageWithCTA/MessageWithCTA.component.tsx with react-docgen. Rerun Storybook with --loglevel=debug to get more info.
+// ERROR in ./src/components/organisms/MessageWithCTA/MessageWithCTA.component.tsx
+// Module build failed (from ./node_modules/@storybook/nextjs/dist/swc/next-swc-loader-patch.js):
+// Error:
 // Props Interface
 export interface TestimonialItemProps {
   quote: string; // The main testimonial text
@@ -20,6 +26,9 @@ const TestimonialItem: React.FC<TestimonialItemProps> = ({
   role,
   quoteImageSrc = '/assets/icons/quote-icon.svg',
 }) => {
+  const theme = useTheme();
+
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   // Construct alt text dynamically
   const altText: string = `Quote ${
     role ? `from ${role}` : ''
@@ -29,17 +38,26 @@ const TestimonialItem: React.FC<TestimonialItemProps> = ({
     <StyledTestimonial>
       <Box>
         <Box
-          sx={{ width: 38, height: 38, marginRight: 2 }}
+          sx={{
+            width: isMobile ? 38 / 1.5 : 38,
+            height: isMobile ? 38 / 1.5 : 38,
+            marginRight: isMobile ? 1 : 2,
+          }}
           className="quoteWrapper"
         >
-          <Image width={38} height={29} alt={altText} src={quoteImageSrc} />
+          <Image
+            width={isMobile ? 38 / 1.5 : 38}
+            height={isMobile ? 38 / 1.5 : 38}
+            alt={altText}
+            src={quoteImageSrc}
+          />
         </Box>
       </Box>
       <Box>
         {/* Quote Text */}
         <TitleText
           sx={{
-            fontSize: 24,
+            fontSize: isMobile ? 20 : 24,
             fontWeight: 800,
           }}
         >
@@ -49,7 +67,7 @@ const TestimonialItem: React.FC<TestimonialItemProps> = ({
         {/* Author and Role */}
         <ParagraphText
           sx={{
-            fontSize: 20,
+            fontSize: isMobile ? 16 : 20,
             marginTop: 1,
             fontWeight: 'bold',
           }}

--- a/src/components/organisms/MessageWithCTA/MessageWithCTA.component.tsx
+++ b/src/components/organisms/MessageWithCTA/MessageWithCTA.component.tsx
@@ -1,11 +1,11 @@
 import ContainedButton from '@/components/atoms/buttons/ContainedButton';
 import ParagraphText from '@/components/atoms/typography/ParagraphText';
 import TitleText from '@/components/atoms/typography/TitleText';
+import useMergeProps from '@/hooks/useMergeProps.hook';
 import { colors } from '@/theme/theme';
 import { BaseButtonProps } from '@/types/base-button-props.interface';
 import { BaseTypographyProps } from '@/types/base-typography-props.interface';
 import { SxProps } from '@mui/material';
-import { useMemo } from 'react';
 import {
   MessageWithCTAButtonWrap,
   MessageWithCTAIconWrap,
@@ -41,8 +41,8 @@ const defaultButtonProps: Partial<CTAButtonProps> = {
   textColor: colors.bridgeDarkPurple,
   backgroundColor: 'white',
   text: 'Click Me',
-  sx: {
-    fontWeight: 'bold',
+  textProps: {
+    fontWeight: '700',
   },
 };
 
@@ -75,22 +75,15 @@ function MessageWithCTA(props: MessageWithCTAProps) {
     icon = null,
   } = props;
 
-  // Merge default and user-provided props
-  const mergeButtonProps = useMemo(
-    () => (buttonProps ? { ...defaultButtonProps, ...buttonProps } : null),
-    [buttonProps]
+  // Merge default and user-provided props using useMergeProps
+  const mergeButtonProps = useMergeProps(defaultButtonProps, buttonProps || {});
+
+  const mergeParagraphProps = useMergeProps(
+    defaultParagraphProps,
+    paragraphProps
   );
 
-  const mergeParagraphProps = useMemo(
-    () => ({ ...defaultParagraphProps, ...paragraphProps }),
-    [paragraphProps]
-  );
-
-  const mergeTitleProps = useMemo(
-    () => ({ ...defaultTitleProps, ...titleProps }),
-    [titleProps]
-  );
-
+  const mergeTitleProps = useMergeProps(defaultTitleProps, titleProps);
   return (
     <MessageWithCTAWrap sx={containerStyles}>
       {icon ? <MessageWithCTAIconWrap>{icon}</MessageWithCTAIconWrap> : null}
@@ -102,7 +95,10 @@ function MessageWithCTA(props: MessageWithCTAProps) {
       </MessageWithCTATitleWrap>
 
       <MessageWithCTAParagraphWrap>
-        <ParagraphText sx={{ ...(mergeParagraphProps.paragraphStyles as any) }}>
+        <ParagraphText
+          fontWeight={'600'}
+          sx={{ ...(mergeParagraphProps.paragraphStyles as any) }}
+        >
           {mergeParagraphProps.paragraphText}
         </ParagraphText>
       </MessageWithCTAParagraphWrap>

--- a/src/components/organisms/MessageWithCTA/MessageWithCTA.stories.tsx
+++ b/src/components/organisms/MessageWithCTA/MessageWithCTA.stories.tsx
@@ -40,6 +40,41 @@ export default meta;
 
 type Story = StoryObj<typeof MessageWithCTA>;
 
+export const Default: Story = {
+  args: {
+    titleProps: {
+      titleText: 'Discover your business’s worth',
+    },
+    paragraphProps: {
+      paragraphText: 'Get a Bridge Certified Valuation for $1,999.',
+
+      paragraphStyles: {
+        color: 'white',
+        sx: {
+          color: 'white',
+        },
+        fontWeight: '800',
+      },
+    },
+    buttonProps: {
+      text: 'Order Certified Valuation',
+      endIcon: <ArrowRight />,
+      onClick: () => alert('Learn More clicked!'),
+      textProps: {
+        fontWeight: 800,
+      },
+    },
+    icon: (
+      <Image
+        width={57.93}
+        height={62.37}
+        alt="Bridge Financial Shield"
+        src={'/assets/icons/bridge-shield-icon.png'}
+      />
+    ),
+  },
+};
+
 export const CustomStyles: Story = {
   args: {
     titleProps: {
@@ -73,30 +108,6 @@ export const WithoutIcon: Story = {
       onClick: () => alert('No icon button clicked!'),
     },
     icon: null, // No icon in this variant
-  },
-};
-
-export const Default: Story = {
-  args: {
-    titleProps: {
-      titleText: 'Discover your business’s worth',
-    },
-    paragraphProps: {
-      paragraphText: 'Get a Bridge Certified Valuation for $1,999.',
-    },
-    buttonProps: {
-      text: 'Order Certified Valuation',
-      endIcon: <ArrowRight />,
-      onClick: () => alert('Learn More clicked!'),
-    },
-    icon: (
-      <Image
-        width={57.93}
-        height={62.37}
-        alt="Bridge Financial Shield"
-        src={'/assets/icons/bridge-shield-icon.png'}
-      />
-    ),
   },
 };
 

--- a/src/components/organisms/headers/LayoutBar/DesktopLayoutBar/DesktopLayoutBar.component.tsx
+++ b/src/components/organisms/headers/LayoutBar/DesktopLayoutBar/DesktopLayoutBar.component.tsx
@@ -6,12 +6,15 @@ import { useTheme } from '@mui/material/styles';
 import React from 'react';
 import { LayoutBarProps } from '../LayoutBar.types';
 
-export interface DesktopLayoutBarProps extends Partial<LayoutBarProps> {}
+export interface DesktopLayoutBarProps extends Partial<LayoutBarProps> {
+  maxWidth?: string;
+}
 
 const DesktopLayoutBar: React.FC<DesktopLayoutBarProps> = ({
   title,
   user,
   logout,
+  maxWidth = '1200px',
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -44,7 +47,7 @@ const DesktopLayoutBar: React.FC<DesktopLayoutBarProps> = ({
             alignItems: 'center',
             justifyContent: 'space-between',
             width: '100%',
-            maxWidth: '1200px',
+            maxWidth: maxWidth,
             color: theme.palette.text.primary,
             paddingY: 2,
             paddingX: 0,

--- a/src/components/templates/layouts/OfferLayout/OfferContent/OfferContent.component.tsx
+++ b/src/components/templates/layouts/OfferLayout/OfferContent/OfferContent.component.tsx
@@ -14,56 +14,21 @@ import MessageWithCTA, {
 } from '@/components/organisms/MessageWithCTA/MessageWithCTA.component';
 import { useViewSize } from '@/hooks/useViewSize.hook';
 import { LayoutForPortalProps } from '@/types/layout.types';
+import { useTheme } from '@mui/material';
 import Box, { BoxProps } from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import Image from 'next/image';
-import { forwardRef, useEffect, useState } from 'react';
+import { forwardRef, useEffect, useMemo, useState } from 'react';
 import { OfferLayoutProps } from '../OfferLayout.component';
-
-// Styled Components
-const ParentContainer = styled(Box)(({ theme }) => ({
-  position: 'relative',
-  width: '100%',
-  marginTop: 0,
-  paddingTop: 0,
-  zIndex: 0,
-  paddingBottom: 30,
-}));
-
-const BannerContainer = styled(Box)(({ theme }) => ({
-  position: 'relative',
-  width: '93%',
-
-  margin: '1% auto',
-  marginTop: 0,
-  paddingTop: 0,
-  zIndex: 1,
-}));
-
-const HeaderSection = styled(Box)(({ theme }) => ({
-  width: '100%',
-  height: '15%',
-  marginBottom: theme.spacing(2),
-}));
-
-const HeroSection = styled(Box)(({ theme }) => ({
-  width: '100%',
-  height: '15%',
-}));
-
-const TestimonialSection = styled(Box)(({ theme }) => ({
-  width: '93%',
-  height: '15%',
-  margin: '1% auto',
-}));
-
-const PreviewSection = styled(Box)(({ theme }) => ({
-  flexDirection: 'column',
-  alignItems: 'center',
-  display: 'flex',
-  marginTop: '5%',
-}));
-
+import {
+  BannerContainerStyled,
+  HeaderSectionStyled,
+  HeroSectionStyled,
+  ParentContainerStyled,
+  PreviewSectionStyled,
+  TestimonialSectionStyled,
+} from './OfferContent.styles';
 // use onclick inside of features,
 // to change the state of videoDetails.opened to true
 // to open the video model
@@ -123,10 +88,15 @@ const TestimonialSectionWithMount = ({
     setIsMounted(true); // Set mounted state after the component mounts
   }, []);
 
+  // it's important to use the style property right here instead of the sx
+  // prop. if you use the sx prop marginTop will not handle the units properly
   return (
-    <TestimonialSection
+    <TestimonialSectionStyled
+      test-id={'display-grid-for-feature-list'}
       style={{
-        marginTop: featureSize.height / 1.3,
+        marginTop: featureSize.height / 2,
+        paddingTop: 100,
+        paddingBottom: 100,
         opacity: isMounted ? 1 : 0, // Set opacity based on mounted state
         transition: 'opacity 0.5s ease-in-out', // Add a smooth transition
       }}
@@ -136,8 +106,8 @@ const TestimonialSectionWithMount = ({
           width: '100%',
           paddingLeft: { xs: 2, sm: 12 },
           paddingRight: { xs: 2, sm: 12 },
-          paddingTop: 5,
-          paddingBottom: 5,
+          paddingTop: 0,
+          paddingBottom: 0,
           borderRadius: 4,
         }}
       >
@@ -147,19 +117,18 @@ const TestimonialSectionWithMount = ({
           data={testimonials}
           spacing={6}
           containerStyle={{
-            width: '100%',
-            padding: 0,
+            padding: 2,
           }}
           itemStyle={{
-            padding: 0,
-            paddingBottom: 4,
+            padding: 5,
+
             width: '100%',
             justifyContent: 'center',
             alignContent: 'center',
           }}
         />
       </Box>
-    </TestimonialSection>
+    </TestimonialSectionStyled>
   );
 };
 const FeaturesSection = forwardRef<HTMLDivElement, FeaturesSectionProps>(
@@ -176,6 +145,7 @@ const FeaturesSection = forwardRef<HTMLDivElement, FeaturesSectionProps>(
     return (
       <FeaturesContainer
         ref={ref}
+        test-id="feature-container"
         style={{
           ...containerStyle,
           opacity: isMounted ? 1 : 0, // Set opacity based on mounted state
@@ -199,13 +169,15 @@ const PreviewSectionWithMount = () => {
   }, []);
 
   return (
-    <PreviewSection
+    <PreviewSectionStyled
       sx={{
         opacity: isMounted ? 1 : 0, // Set opacity based on mounted state
         transition: 'opacity 0.5s ease-in-out', // Add a smooth transition
       }}
+      test-id="preview-container"
     >
       <Box
+        test-id="preview-container-text-wrapper"
         sx={{
           width: '90%',
           backgroundColor: 'white',
@@ -225,7 +197,7 @@ const PreviewSectionWithMount = () => {
           PDF
         </TitleText>
       </Box>
-    </PreviewSection>
+    </PreviewSectionStyled>
   );
 };
 
@@ -242,13 +214,19 @@ const OfferContent = (props: OfferContentProps) => {
       url: '',
     },
   } = props;
+  const theme = useTheme();
+
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   // Use hooks to track sizes
   const [featureSize, setFeatureRef] = useViewSize();
   const [gradientSize, setGradientRef] = useViewSize();
 
   // Calculate styles dynamically
-  const featureSizeHalf = featureSize.height / 2;
+  const featureSizeHalf = useMemo(
+    () => featureSize.height / 2,
+    [featureSize.height]
+  );
 
   return (
     <>
@@ -257,8 +235,7 @@ const OfferContent = (props: OfferContentProps) => {
         onClose={() => videoDetails.onClose()}
         url={videoDetails.url}
       />
-      <ParentContainer>
-        {/* Gradient Section */}
+      <ParentContainerStyled>
         <GradientBox
           ref={setGradientRef}
           direction="to right"
@@ -273,11 +250,11 @@ const OfferContent = (props: OfferContentProps) => {
             paddingBottom: featureSize.height / 1.5,
           }}
         >
-          <BannerContainer>
-            <HeaderSection>
-              <DesktopLayoutBar user={user} logout={logout} />
-            </HeaderSection>
-            <HeroSection>
+          <BannerContainerStyled>
+            <HeaderSectionStyled>
+              <DesktopLayoutBar maxWidth="100%" user={user} logout={logout} />
+            </HeaderSectionStyled>
+            <HeroSectionStyled>
               <MessageWithCTA
                 containerStyles={{
                   marginTop: 0,
@@ -311,8 +288,8 @@ const OfferContent = (props: OfferContentProps) => {
                 }}
                 buttonProps={messageWithCta.buttonProps || null}
               />
-            </HeroSection>
-          </BannerContainer>
+            </HeroSectionStyled>
+          </BannerContainerStyled>
         </GradientBox>
 
         {/* Features Section */}
@@ -323,6 +300,7 @@ const OfferContent = (props: OfferContentProps) => {
           containerStyle={{ margin: 'auto' }}
         >
           <DisplayGrid
+            test-id={'display-grid-for-feature-list'}
             renderItem={(item) => <FeatureListItem {...item} />}
             data={features}
             itemStyle={{
@@ -352,7 +330,7 @@ const OfferContent = (props: OfferContentProps) => {
 
         {/* Preview Section */}
         <PreviewSectionWithMount />
-      </ParentContainer>
+      </ParentContainerStyled>
     </>
   );
 };

--- a/src/components/templates/layouts/OfferLayout/OfferContent/OfferContent.stories.tsx
+++ b/src/components/templates/layouts/OfferLayout/OfferContent/OfferContent.stories.tsx
@@ -64,7 +64,7 @@ const sampleFeatureDataUsingImages: FeatureListItemProps[] = [
         src="/assets/icons/checkmark-circle-icon.svg"
       />
     ),
-    text: 'Obtain a certified valuation and discover growth opportunities for revenue and value.',
+    text: 'Obtain a certified valuation and pdiscover growth opportunities for revenue and value.',
   },
   {
     icon: (
@@ -81,8 +81,8 @@ const sampleFeatureDataUsingImages: FeatureListItemProps[] = [
     icon: (
       <Image
         alt="video-play-icon"
-        width={18}
-        height={18}
+        width={25}
+        height={25}
         src="/assets/icons/video-play-favicon.svg"
       />
     ),
@@ -95,12 +95,9 @@ const sampleFeatureDataUsingImages: FeatureListItemProps[] = [
 export default {
   title: 'components/templates/layouts/OfferLayout/OfferContent',
   component: OfferContent,
-  parameters: {
-    // layout: 'centered',
-  },
 } as Meta<any>;
 
-const Template: StoryObj<any> = {
+export const Desktop = {
   args: {
     testimonials,
     features: sampleFeatureDataUsingImages,
@@ -118,6 +115,35 @@ const Template: StoryObj<any> = {
       },
     },
   },
+  parameters: {
+    viewport: {
+      defaultViewport: 'Desktop',
+    },
+  },
 };
 
-export const Default = Template;
+// Story in Mobile View
+export const OnMobile: StoryObj<any> = {
+  args: {
+    testimonials,
+    features: sampleFeatureDataUsingImages,
+    messageWithCta: {
+      titleProps: {
+        titleText: 'Discover your business’s worth',
+      },
+      paragraphProps: {
+        paragraphText: 'Get a Bridge Certified Valuation for $1,999.',
+      },
+      buttonProps: {
+        text: 'Order Certified Valuation',
+        endIcon: <ArrowRight />,
+        onClick: () => alert('Learn More clicked!'),
+      },
+    },
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'smallDevicePortrait',
+    },
+  },
+};

--- a/src/components/templates/layouts/OfferLayout/OfferContent/OfferContent.styles.tsx
+++ b/src/components/templates/layouts/OfferLayout/OfferContent/OfferContent.styles.tsx
@@ -1,0 +1,49 @@
+import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+// Styled Components
+export const ParentContainerStyled = styled(Box)(({ theme }) => ({
+  position: 'relative',
+  width: '100%',
+  marginTop: 0,
+  paddingTop: 0,
+  zIndex: 0,
+  paddingBottom: 30,
+}));
+
+export const BannerContainerStyled = styled(Box)(({ theme }) => ({
+  position: 'relative',
+  width: '93%',
+
+  margin: '1% auto',
+  marginTop: 0,
+  paddingTop: 0,
+  zIndex: 1,
+}));
+
+export const HeaderSectionStyled = styled(Box)(({ theme }) => ({
+  width: '100%',
+  height: '15%',
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  marginBottom: theme.spacing(2),
+}));
+
+export const HeroSectionStyled = styled(Box)(({ theme }) => ({
+  width: '100%',
+  height: '15%',
+}));
+
+export const TestimonialSectionStyled = styled(Box)(({ theme }) => ({
+  width: '93%',
+  height: '15%',
+  margin: '1% auto',
+}));
+
+export const PreviewSectionStyled = styled(Box)(({ theme }) => ({
+  flexDirection: 'column',
+  alignItems: 'center',
+  display: 'flex',
+  marginTop: '5%',
+}));

--- a/src/components/templates/layouts/OfferLayout/OfferLayout.component.tsx
+++ b/src/components/templates/layouts/OfferLayout/OfferLayout.component.tsx
@@ -127,8 +127,9 @@ export const OfferLayout: React.FC<OfferLayoutProps> = ({
       test-id={'offer-layout'}
       style={{
         display: 'flex',
-        backgroundColor: 'transparent',
+
         width: '100%',
+        backgroundColor: '#FBFBFB',
         flexDirection: 'column',
         overflowY: 'auto',
       }}

--- a/src/components/templates/layouts/OfferLayout/OfferLayout.stories.tsx
+++ b/src/components/templates/layouts/OfferLayout/OfferLayout.stories.tsx
@@ -83,8 +83,8 @@ const sampleFeatureDataUsingImages = [
     icon: (
       <Image
         alt="video-play-icon"
-        width={18}
-        height={18}
+        width={25}
+        height={25}
         src="/assets/icons/video-play-favicon.svg"
       />
     ),

--- a/src/hooks/useMergeProps.hook.tsx
+++ b/src/hooks/useMergeProps.hook.tsx
@@ -1,0 +1,67 @@
+import merge from 'lodash.merge';
+import { useMemo } from 'react';
+
+// This will replace the useMergeStyles hook if it works well.
+// we can delete useMergeStyles hook later, and replace it with this
+// it makes more sense to  have a useMergeProps because you might want to merge
+// default props with incoming props and not just styles
+
+/**
+ * A custom hook to merge any type of objects into one, including deeply nested properties.
+ *
+ * @param {Record<string, any>} defaultProps - The default object that serves as a base.
+ * @param {Record<string, any>} customProps - The custom object that will override default values.
+ * @returns {Record<string, any>} - The merged object.
+ *
+ * @example
+ * const defaultProps = {
+ *   settings: {
+ *     theme: 'light',
+ *     user: {
+ *       name: 'Default User',
+ *       preferences: {
+ *         notifications: true,
+ *       },
+ *     },
+ *   },
+ * };
+ *
+ * const customProps = {
+ *   settings: {
+ *     theme: 'dark', // Override default theme
+ *     user: {
+ *       preferences: {
+ *         notifications: false, // Override default notifications
+ *       },
+ *     },
+ *   },
+ * };
+ *
+ * const mergedProps = useMergeProps(defaultProps, customProps);
+ * // mergedProps will be:
+ * // {
+ * //   settings: {
+ * //     theme: 'dark',
+ * //     user: {
+ * //       name: 'Default User',
+ * //       preferences: {
+ * //         notifications: false,
+ * //       },
+ * //     },
+ * //   },
+ * // }
+ */
+function useMergeProps<T extends Record<string, any>>(
+  defaultProps: T,
+  customProps: T
+): T {
+  // Memoize the merged object to avoid unnecessary recalculations
+  const mergedProps = useMemo(
+    () => merge({}, defaultProps, customProps),
+    [defaultProps, customProps]
+  );
+
+  return mergedProps;
+}
+
+export default useMergeProps;

--- a/src/hooks/useViewSize.hook.tsx
+++ b/src/hooks/useViewSize.hook.tsx
@@ -1,22 +1,18 @@
-import { useCallback, useReducer } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 
 // Initial state
 const initialState = {
   width: 0,
   height: 0,
-  top: 0,
-  left: 0,
-  bottom: 0,
-  right: 0,
+  top: 0, // Distance from the top of the document
+  bottom: 0, // Distance from the top of the document + height
 };
 
-// Reducer for state updates
 const sizeReducer = (
   state: typeof initialState,
   action: Partial<typeof initialState>
 ) => ({ ...state, ...action });
 
-// Hook to measure size and position
 export const useViewSize = () => {
   const [size, dispatch] = useReducer(sizeReducer, initialState);
 
@@ -25,13 +21,13 @@ export const useViewSize = () => {
 
     const updateSize = () => {
       const rect = node.getBoundingClientRect();
+      const scrollY = window.scrollY || 0;
+
       dispatch({
         width: rect.width,
         height: rect.height,
-        top: rect.top,
-        left: rect.left,
-        bottom: rect.bottom,
-        right: rect.right,
+        top: rect.top + scrollY, // Calculate top relative to the document
+        bottom: rect.bottom + scrollY, // Calculate bottom relative to the document
       });
     };
 
@@ -42,6 +38,17 @@ export const useViewSize = () => {
     resizeObserver.observe(node);
 
     return () => resizeObserver.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const handleUpdate = () => dispatch({});
+    window.addEventListener('resize', handleUpdate);
+    window.addEventListener('scroll', handleUpdate);
+
+    return () => {
+      window.removeEventListener('resize', handleUpdate);
+      window.removeEventListener('scroll', handleUpdate);
+    };
   }, []);
 
   return [size, callbackRef] as const;

--- a/src/providers/Main.provider.tsx
+++ b/src/providers/Main.provider.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { ColorsProvider } from './Color.provider';
-import { LoggerStateProvider } from './LoggerProvider/Logger.provider';
+import LoggerStateProvider  from './LoggerProvider/Logger.provider';
 import { ToastNotificationProvider } from './ToastNotification.provider';
 
 interface MainProviderProps {


### PR DESCRIPTION
## 🚀 Pull Request

### Description

- **What does this PR do?**
 fixes styling issues with offer template, as well as changes with the useViewHook and how the behavior works with that layout.
 
Made examples of how to make title text, and paragraph text, different font weights in the stories. 

changed **MessageWithCTA** in **OfferLayout** uses **semibold** text  for the paragraph and **bold** text for the bottom.



- **Why is this change required?**
 because it needs to be presentable and LJ pointed out things that he wanted fixed with the css
- **What issue(s) does this address (if applicable)?**  
  Closes: #86 

---

### ✅ Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [ ] ✨ New feature (adds functionality)
- [x] 🛠 Improvement (improves performance, code quality, etc.)
- [x] 📚 Documentation update (adds or updates documentation)
- [ ] 🔄 Maintenance (dependency updates, chore tasks, etc.)

---

### 💡 Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/0c2d5521-bbb5-4790-87e7-335bc566b407)

---

### 🔍 Additional Context

Before with this layout the feature list (which is the list with the checkmarks and call to action) that is above the purple background, and grey background. is aligned right. but when you would resize the window it would break. I think I fixed that by switching the way the useViewSize hook worked. 

In my opinion if it was me, I would say to put the feature list in one container (the purple, or gray) and not have it aligned to the middle to the both. It's going to take more time to program these types of layouts and make them responsive. 

I still need to work on making the testimonials look good on mobile, but I will put that in a different pull request. It's mostly the spacing around them and between them on the offer layout that need to be adjusted.  

