### PR TITLE
logo fix

### DIFF
--- a/src/components/atoms/images/LogoImage/LogoImage.component.tsx
+++ b/src/components/atoms/images/LogoImage/LogoImage.component.tsx
@@ -8,9 +8,9 @@ export interface LogoProps extends Omit<ImageProps, 'src' | 'alt'> {
   alt?: string;
 }
 
-// Default properties for LogoImage
+// this right here needs to be "assets/" or the image is going to break for the layout
 export const DefaultLogoProps = {
-  src: '/assets/images/Bridge-logo.png',
+  src: 'assets/images/Bridge-logo.png',
   alt: 'Bridge Financial Logo',
   height: 34.23,
   width: 120,


### PR DESCRIPTION
I just changed the path for the default props for DefaultLogoProps. 
I don't know when this got changed. it could have been when I updated it last? I don't know 
BUT in staging and production right now the logo is broken and this is why. 

by switching "./assets" to "assets" it fixes it