### PR TITLE
SER-86b31ut3w/fix-not-sure-button-unchecked-on-edit

### DIFF
--- a/src/components/organisms/forms/FormField.tsx
+++ b/src/components/organisms/forms/FormField.tsx
@@ -550,7 +550,8 @@ const FormField = forwardRef(
               placeholder={formField.placeholder || defaultPlaceholder}
               className="fmd-input"
               value={
-                formValues[formField.name] &&
+                // handle zero values correctly; prevents 0 from being treated as false
+                formValues[formField.name] != null &&
                 FieldInformationService.isValidUserInput(
                   formField.type,
                   formValues[formField.name],

--- a/src/components/organisms/forms/FormField.tsx
+++ b/src/components/organisms/forms/FormField.tsx
@@ -429,7 +429,11 @@ const FormField = forwardRef(
             size="small"
             min={formField.min}
             max={formField.max}
-            value={formValues[formField.name] ?? 0}
+            value={
+              formValues[formField.name] == 'Not sure'
+                ? 0
+                : (formValues[formField.name] ?? 0)
+            }
             onChange={(e, value) => {
               handleChange(formField.name, value);
             }}

--- a/src/providers/Questionnaire.provider.tsx
+++ b/src/providers/Questionnaire.provider.tsx
@@ -226,6 +226,11 @@ export const QuestionnaireProvider = ({
             FieldInformationService.isNumber(field.type) &&
             typeof formValues[field.name] === 'string'
           ) {
+            // Check if the value is "Not sure" to prevent parseFloat from transforming it into NaN
+            if (formDataValues[field.name] === 'Not sure') {
+              return formDataValues[field.name];
+            }
+
             formDataValues[field.name] = parseFloat(
               formValues[field.name]?.replaceAll(',', '') ?? ''
             );


### PR DESCRIPTION
**Problem**

1. "Not Sure" Handling Bug:

  - If the value was "Not sure," parseFloat transformed it into NaN during submission, causing it to be stored as null in the database.

  - When users revisited the form, the frontend checked for "Not sure", but since the database stored null, the checkbox was unchecked, requiring users to select it again.

2. Zero Value Handling Bug:

  - When users entered 0 in a numeric field, the value was omitted when revisiting the page for editing. This happened because the condition `formValues[formField.name]` treated 0 as false, causing the value to appear empty. Users had to re-enter the value.

**What I Did**

1. Added a safeguard to check if the value is "Not sure" before calling `parseFloat`. If the value is "Not sure", it is preserved and returned, preventing it from being transformed into NaN and stored as null.

2. Updated the condition `formValues[formField.name` to `formValues[formField.name] != null` to correctly handle zero (0) as a valid value.

Tested out after making changes. This covers all questionnaires cases.