### PR TITLE
 SER-86b31utjt/fix-saved-data-not-deleted-on-signout

### DIFF
--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -1,6 +1,7 @@
 import { useToastNotification } from '@/providers/ToastNotification.provider';
 import { routePaths } from '@/types/routes.enum';
 import { User } from '@/types/users.types';
+import { clearQuestionnaireData } from '@/utils/local-storage';
 import {
   useMutation,
   UseMutationResult,
@@ -131,6 +132,7 @@ export const useLogoutUser = (): UseMutationResult<
   return useMutation({
     mutationFn: logoutUser,
     onSuccess: () => {
+      clearQuestionnaireData();
       queryClient.invalidateQueries({ queryKey: ['session'] });
       router.push(routePaths.LOGIN);
     },

--- a/src/utils/local-storage.ts
+++ b/src/utils/local-storage.ts
@@ -1,3 +1,14 @@
 export const getLandingConfigKey = (formId: number) => {
   return `last-viewed-config-form-id-${formId}`;
 };
+
+export const clearQuestionnaireData = () => {
+  Object.keys(localStorage).forEach((key) => {
+    if (
+      key.startsWith('questionnaire-responses-') ||
+      key.startsWith('last-viewed-config-form-id')
+    ) {
+      localStorage.removeItem(key); // Remove the key
+    }
+  });
+};


### PR DESCRIPTION
added clearQuestionnaireData function to local storage utils

This function will delete all the questionnaire's data that have been saved to Local Storage by clicking on Save & Exit button during each Valuation, Optimize, and Sell my Business questionnaire process.

This function is called when user successfully signs out. 