### PR TITLE
SER-86b31utf9/add-visibility-icon-to-password-reset-inputs

### DIFF
--- a/src/app/auth/login/LoginForm/LoginForm.component.tsx
+++ b/src/app/auth/login/LoginForm/LoginForm.component.tsx
@@ -10,13 +10,7 @@ import { routePaths } from '@/types/routes.enum';
 import { User } from '@/types/users.types';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import React, {
-  ChangeEvent,
-  FormEvent,
-  MouseEvent,
-  useState,
-  useEffect,
-} from 'react';
+import React, { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 
 // Define types for form values and errors
 interface FormValues {
@@ -72,11 +66,6 @@ export const LoginForm: React.FC<LoginFormProps> = ({
       ...formValues,
       [name]: value,
     });
-  };
-
-  // Handle mouse down event
-  const handleOnMouseDown = (event: MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault(); // Prevent the button from gaining focus
   };
 
   // Validate form fields
@@ -151,7 +140,6 @@ export const LoginForm: React.FC<LoginFormProps> = ({
           onChange={handleChange}
           error={Boolean(formErrors && formErrors.password)}
           helperText={formErrors?.password}
-          handleOnMouseDown={handleOnMouseDown}
         />
 
         <ParagraphText variant="body2" align="left" sx={{ mt: 3, mb: 3 }}>

--- a/src/app/auth/password-reset/[uid]/[token]/PasswordResetConfirmForm/PasswordResetConfirmForm.component.tsx
+++ b/src/app/auth/password-reset/[uid]/[token]/PasswordResetConfirmForm/PasswordResetConfirmForm.component.tsx
@@ -84,7 +84,6 @@ const PasswordResetConfirmForm: React.FC = () => {
             error={Boolean(error && newPassword === '')}
             helperText={error && newPassword === '' ? error : ''}
             fullWidth={true}
-            handleOnMouseDown={(event) => event.preventDefault()}
           />
           <SecureTextInputGroup
             label="Confirm New Password"
@@ -94,7 +93,6 @@ const PasswordResetConfirmForm: React.FC = () => {
             error={Boolean(error && confirmPassword === '')}
             helperText={error && confirmPassword === '' ? error : ''}
             fullWidth={true}
-            handleOnMouseDown={(event) => event.preventDefault()}
           />
           {error && (
             <Typography color="error" variant="body2" align="center">

--- a/src/app/auth/sign-up/SignUpForm/SignUpForm.component.tsx
+++ b/src/app/auth/sign-up/SignUpForm/SignUpForm.component.tsx
@@ -18,7 +18,7 @@ import {
   Typography,
 } from '@mui/material';
 import Link from 'next/link';
-import React, { MouseEvent, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 export interface SignUpFormProps {
   title?: string;
@@ -141,11 +141,6 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
     }
   };
 
-  // Handle mouse down event
-  const handleOnMouseDownForSecure = (event: MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault(); // Prevent the button from gaining focus
-  };
-
   return (
     <CardWithTitle
       containerStyle={cardContainerStyles}
@@ -266,7 +261,6 @@ export const SignUpForm: React.FC<SignUpFormProps> = ({
           onChange={handleChange}
           error={Boolean(errors && errors.password)}
           helperText={errors?.password}
-          handleOnMouseDown={handleOnMouseDownForSecure}
           onBlur={handleBlur}
         />
         <FormControlLabel

--- a/src/app/portal/settings/SettingTabs/ChangePasswordForm/ChangePasswordForm.component.tsx
+++ b/src/app/portal/settings/SettingTabs/ChangePasswordForm/ChangePasswordForm.component.tsx
@@ -4,7 +4,7 @@ import ContainedButton from '@/components/atoms/buttons/ContainedButton';
 import ParagraphText from '@/components/atoms/typography/ParagraphText';
 import TitleText from '@/components/atoms/typography/TitleText';
 import ToastNotification from '@/components/molecules/feedback/ToastNotification';
-import TextInputGroup from '@/components/molecules/forms/TextInputGroup';
+import SecureTextInputGroup from '@/components/molecules/forms/SecureTextInputGroup';
 import { useChangePassword, useSessionUser } from '@/services/users.service';
 import { colors } from '@/theme/theme';
 import { Box } from '@mui/material';
@@ -157,9 +157,8 @@ const ChangePasswordForm: React.FC = () => {
       </Box>
 
       {/* Current Password Input */}
-      <TextInputGroup
+      <SecureTextInputGroup
         label="Current password"
-        type="password"
         fullWidth={true}
         margin="normal"
         name="password"
@@ -170,9 +169,8 @@ const ChangePasswordForm: React.FC = () => {
       />
 
       {/* New Password Input */}
-      <TextInputGroup
+      <SecureTextInputGroup
         label="New password"
-        type="password"
         fullWidth={true}
         margin="normal"
         name="password1"
@@ -183,9 +181,8 @@ const ChangePasswordForm: React.FC = () => {
       />
 
       {/* Confirm Password Input */}
-      <TextInputGroup
+      <SecureTextInputGroup
         label="Confirm password"
-        type="password"
         fullWidth={true}
         margin="normal"
         name="password2"

--- a/src/components/molecules/forms/SecureTextInputGroup/SecureTextInputGroup.component.tsx
+++ b/src/components/molecules/forms/SecureTextInputGroup/SecureTextInputGroup.component.tsx
@@ -91,7 +91,7 @@ const SecureTextInputGroup: React.FC<SecureTextInputGroupProps> = ({
     {}
   );
 
-  // Need to put both on OnMouseDown and OnMouseUp
+  // Add this to both OnMouseDown and OnMouseUp to prevent the cursor from jumping to the start.
   // Reference: https://github.com/mui/material-ui/issues/26007
   const handleMouseInteraction = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault(); // Prevent the button from gaining focus

--- a/src/components/molecules/forms/SecureTextInputGroup/SecureTextInputGroup.component.tsx
+++ b/src/components/molecules/forms/SecureTextInputGroup/SecureTextInputGroup.component.tsx
@@ -8,14 +8,13 @@ import {
   TextField,
   TextFieldProps,
 } from '@mui/material';
-import React, { useState } from 'react';
+import React, { MouseEvent, useState } from 'react';
 
 // Define the types for icon components
 export type IconComponent = React.ComponentType<React.SVGProps<SVGSVGElement>>;
 
 export interface SecureTextInputGroupProps
   extends Omit<TextFieldProps, 'variant' | 'type'> {
-  handleOnMouseDown: (event: React.MouseEvent<HTMLButtonElement>) => void;
   SecureTextOnIcon?: IconComponent;
   SecureTextOffIcon?: IconComponent;
   sx?: TextFieldProps['sx'];
@@ -33,7 +32,6 @@ export interface SecureTextInputGroupProps
  * @param {boolean} [error] - If true, the input will be displayed in an error state.
  * @param {boolean} [isSecure=false] - Determines whether the input field should hide the entered text (i.e., treat it as a password).
  * @param {() => void} securePressOnChange - Function that gets called when the visibility toggle button is clicked.
- * @param {(event: React.MouseEvent<HTMLButtonElement>) => void} handleOnMouseDown - Function that gets called on the mouse down event of the visibility toggle button.
  * @param {boolean} [fullWidth] - If true, the input field will take up the full width of its container.
  * @param {string} [helperText] - Helper text to display below the input field.
  * @param {IconComponent} [SecureTextOnIcon=Visibility] - Icon to display when the text is hidden (secure mode), default is `Visibility`.
@@ -49,13 +47,12 @@ export interface SecureTextInputGroupProps
  *   onChange={handlePasswordChange}
  *   isSecure={isPasswordHidden}
  *   securePressOnChange={togglePasswordVisibility}
- *   handleOnMouseDown={handleMouseDown}
  * />
  *
  * @remarks
  * - `isSecure`: When `true`, the input field will mask the text as a password. The icon displayed will also change accordingly.
  * - `SecureTextOnIcon` and `SecureTextOffIcon` are optional props that allow the developer to pass custom icons for the secure text toggle button. By default, `Visibility` and `VisibilityOff` icons from MUI are used.
- * - The developer is responsible for passing down the `securePressOnChange`, `handleOnMouseDown`, `onChange`, and `SecureOnChange` functions to ensure the component behaves as expected.
+ * - The developer is responsible for passing down the `securePressOnChange`, `onChange`, and `SecureOnChange` functions to ensure the component behaves as expected.
  */
 const SecureTextInputGroup: React.FC<SecureTextInputGroupProps> = ({
   label,
@@ -64,7 +61,6 @@ const SecureTextInputGroup: React.FC<SecureTextInputGroupProps> = ({
   margin = 'normal',
   onChange,
   error,
-  handleOnMouseDown,
   fullWidth,
   helperText,
   SecureTextOnIcon = Visibility,
@@ -95,6 +91,12 @@ const SecureTextInputGroup: React.FC<SecureTextInputGroupProps> = ({
     {}
   );
 
+  // Need to put both on OnMouseDown and OnMouseUp
+  // Reference: https://github.com/mui/material-ui/issues/26007
+  const handleMouseInteraction = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault(); // Prevent the button from gaining focus
+  };
+
   return (
     <TextField
       sx={mergedStyles}
@@ -115,7 +117,8 @@ const SecureTextInputGroup: React.FC<SecureTextInputGroupProps> = ({
             <IconButton
               aria-label="toggle password visibility"
               onClick={() => setIsSecure((prev) => !prev)}
-              onMouseDown={handleOnMouseDown}
+              onMouseDown={handleMouseInteraction}
+              onMouseUp={handleMouseInteraction}
               edge="end"
               sx={{
                 width: '36px', // Set width to create a square button

--- a/src/components/molecules/forms/SecureTextInputGroup/SecureTextInputGroup.stories.tsx
+++ b/src/components/molecules/forms/SecureTextInputGroup/SecureTextInputGroup.stories.tsx
@@ -20,7 +20,6 @@ const meta: Meta<typeof SecureTextInputGroup> = {
 
     fullWidth: { control: 'boolean' },
     onChange: { action: 'changed' },
-    handleOnMouseDown: { action: 'mouseDown' },
   },
   args: {
     label: 'Password',


### PR DESCRIPTION
This PR enhances the functionality and user experience of the password reset input fields by addressing key issues and adding new features.

1. Add visibility Icon for password fields
2. Cursor position bug fix
3. Refactor `onMouseDown` prop handling