### PR TITLE
display error messages when logging in

### DIFF
--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -69,7 +69,8 @@ export const loginUser = async ({
       throw new Error(`HTTP error! Status: ${response.status}`);
     } else {
       throw new Error(
-        data.non_field_errors?.[0] ?? 'An unknown error occurred',
+        data.error?.non_field_errors?.[0]?.message ??
+          'An unknown error occurred',
       );
     }
   }

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -251,8 +251,16 @@ export const passwordReset = async ({ email }: PasswordResetRequest) => {
     }),
   });
 
+  const data = await response.json();
+
   if (!response.ok) {
-    throw new Error(`HTTP error! Status: ${response.status}`);
+    if (!data) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    } else {
+      throw new Error(
+        data.error?.email?.[0]?.message ?? 'An unknown error occurred',
+      );
+    }
   }
 
   return;

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -251,9 +251,8 @@ export const passwordReset = async ({ email }: PasswordResetRequest) => {
     }),
   });
 
-  const data = await response.json();
-
   if (!response.ok) {
+    const data = await response.json();
     if (!data) {
       throw new Error(`HTTP error! Status: ${response.status}`);
     } else {

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -384,11 +384,18 @@ export const changePassword = async ({
     }),
   });
 
+  const data = await response.json();
+
   if (!response.ok) {
-    throw new Error(`HTTP error! Status: ${response.status}`);
+    if (!data) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    } else {
+      throw new Error(
+        data.error?.password?.[0]?.message ?? 'An unknown error occurred',
+      );
+    }
   }
 
-  const data = await response.json();
   return data;
 };
 


### PR DESCRIPTION
takes advantage of serialized error data in backend (see backend PR @ https://github.com/bridgefinancial/bridge-portal/pull/19) to show specific error messages when logging in, changing password, and resetting password